### PR TITLE
RE-2972 Upgrading maven release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.maven.jxr.plugin>2.3</version.maven.jxr.plugin>
         <version.maven.pmd.plugin>2.7.1</version.maven.pmd.plugin>
         <version.maven.project.info.plugin>2.7</version.maven.project.info.plugin>
-        <version.maven.release.plugin>2.5</version.maven.release.plugin>
+        <version.maven.release.plugin>2.5.2</version.maven.release.plugin>
         <version.maven.resources.plugin>2.6</version.maven.resources.plugin>
         <version.maven.shade.plugin>2.2</version.maven.shade.plugin>
         <version.maven.site.plugin>3.3</version.maven.site.plugin>

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,4 +1,5 @@
 What's new in 2.3.1
+    Updates maven-release-plugin to 2.5.2 [RE-2972]
     Updates maven-checkstyle-plugin to 2.15
 
 What's new in 2.3.0


### PR DESCRIPTION
Fixes a bug with releasing projects whose pom files are not in the root directory.

Release notes
* [2.5.1](https://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=11144&version=20578)
* [2.5.2](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12317824&version=12331215)