### PR TITLE
Increase curator version to 2.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <!-- =========================================================================== -->
         <!--  Third party library versions                                               -->
         <!-- =========================================================================== -->
-        <version.curator>2.4.2</version.curator>
+        <version.curator>2.9.1</version.curator>
         <version.codahale.metrics>3.0.2</version.codahale.metrics>
         <version.commons.lang3>3.3.2</version.commons.lang3>
         <version.commons.math3>3.2</version.commons.math3>

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -1,3 +1,6 @@
+What's new in 2.6.0
+    Update Apache Curator version to 2.9.1
+
 What's new in 2.5.1
     Updates maven-checkstyle-plugin to 2.17
 


### PR DESCRIPTION
NO-REF

The benefit of increasing the curator version that was seen in a
subproject was that curator-test now throws an exception if the
in-memory ZK fails to start. Other changes in the intermediate releases
are bugfixes and improvements so depending on the new version shouldn't
break old code.

@mdgreenfield for review