### PR TITLE
Reduce maven surefire forkCount from 1C => 0.5C

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.reporting.outputEncoding>${default.encoding}</project.reporting.outputEncoding>
         <maven.failsafe.argLine>-XX:+HeapDumpOnOutOfMemoryError -Xmx1024M -XX:MaxPermSize=256M -Djava.awt.headless=true</maven.failsafe.argLine>
         <maven.surefire.argLine>-XX:+HeapDumpOnOutOfMemoryError -Xmx1024M -XX:MaxPermSize=256M -Djava.awt.headless=true</maven.surefire.argLine>
-        <maven.surefire.fork.count>1C</maven.surefire.fork.count>
+        <maven.surefire.fork.count>0.5C</maven.surefire.fork.count>
         <maven.test.runOrder>hourly</maven.test.runOrder>
         <version.buildnumber.plugin>1.3</version.buildnumber.plugin>
         <version.maven.assembly.plugin>2.4.1</version.maven.assembly.plugin>


### PR DESCRIPTION
This pom currently sets the surefire forkCount to 1C, or 1 JVM per core, which has a few potential issues as a default:

1. CPUs with HyperThreading (read most Apple laptops) report 2x as many cpu's as physical cores, so a setting of 1C on a quad core CPU will actually run 8 JVMs simultaneously, 
1. In the case where reuseForks is set to false, which is common for many things inheriting downwards from this, every single unit test will spin up its own jvm, execute a test that generally takes between 20 and 200ms and then shutdown the jvm, in parallel with a swarm of other jvms. In conjunction with the hyper threading cpu count above, this results in 8 JVMs being spun up and torn down constantly and tons of thread contention that causes cpu load and load averages to spike up.
1. In the case that reuseForks _is_ set to true, the overhead of multiple JVM's both in startup and managing tests does not always actually yield a gain for unit testing speed. While such forking can be super helpful for integration/failsafe tests that may hit db's, APIS, and other more latency bound resources, the increased overhead for small unit tests overshadows any gains.

As an example, on my local computer, qith a quad core hyper threadable cpu reporting 8 cores, running `mvn clean test` on a project with 527 unit tests over about 30 files yields the following run times (all notated in seconds, and including all phases executed by a mvn clean test execution):

| forkCount | no reuse | reuse |
|-----------|----------|-------|
|     0     | 17       | 18    |
| 1         | 206      | 23    |
| 0.25C     | 158      | 22    |
| 0.5C      | 139      | 24    |
| 1C        | 140      | 34    |

in the case of no fork reuse, not forking (implicitly running all tests in the same parent jvm that maven initiated) results in by far the fastest time, following by 0.5C and 1C. But between 0.5C and 1C, the CPU load average, amount of fan rpm spin up and impact to other things (i.e. chrome, itunes playback, etc), 0.5C is a much better citizen of the laptop, then 1C which brings most things on the machine to a halt

In the case of fork reuse, staying within the maven jvm is still the fastest, and the rest are all equal, except 1C which due to the previously mentioned thread contention issues of having 2x the real number of cores threads actively working, actually takes nearly a third longer than any other option.

Most likely 0 is not a great default, as there is some value potentially to keeping the tests running in their own JVM by default, and because I think some inheritors of this pom probably also rely on this value for the fork mode for failsafe, changing it from a C based value to just 1 may have a negative impact, so for this pull request I've put in 0.5C which should not impact anything negatively in a meaningful way, but will mitigate some of the more negative cases.